### PR TITLE
3 layers board system

### DIFF
--- a/src/pages/Game/Board/BackPanels.jsx
+++ b/src/pages/Game/Board/BackPanels.jsx
@@ -3,12 +3,13 @@ import { useBoard } from "./Board";
 export default function BackPanels() {
   const { positions, size, panels } = useBoard();
   const panelSize = size / 8;
+  const backPanels = [];
 
   for (let rank = 0; rank < 8; rank++) {
     for (let file = 0; file < 8; file++) {
-      if (panels[rank][file]) {
+      if (panels[rank][file] >= 2) {
         const { x, y } = positions[rank][file];
-        panels.push(
+        backPanels.push(
           <BackPanel
             x={x}
             y={y}
@@ -20,7 +21,7 @@ export default function BackPanels() {
       }
     }
   }
-  return panels.map((panel) => panel);
+  return backPanels.map((panel) => panel);
 }
 
 function BackPanel({ x, y, size, code }) {
@@ -45,9 +46,9 @@ function getSvgFromCode(code) {
   const defaultPiece = "/icons/clover-spiked.svg";
 
   switch (code) {
-    case 1:
-      return localStorage.getItem("icon-move") || defaultMove;
     case 2:
+      return localStorage.getItem("icon-move") || defaultMove;
+    case 3:
       return localStorage.getItem("icon-capture") || defaultCapture;
     default:
       return localStorage.getItem("icon-piece") || defaultPiece;

--- a/src/pages/Game/Board/BackPanels.jsx
+++ b/src/pages/Game/Board/BackPanels.jsx
@@ -1,0 +1,55 @@
+import { useBoard } from "./Board";
+
+export default function BackPanels() {
+  const { positions, size, panels } = useBoard();
+  const panelSize = size / 8;
+
+  for (let rank = 0; rank < 8; rank++) {
+    for (let file = 0; file < 8; file++) {
+      if (panels[rank][file]) {
+        const { x, y } = positions[rank][file];
+        panels.push(
+          <BackPanel
+            x={x}
+            y={y}
+            size={panelSize}
+            code={panels[rank][file]}
+            key={`back-panel-${rank}-${file}`}
+          />
+        );
+      }
+    }
+  }
+  return panels.map((panel) => panel);
+}
+
+function BackPanel({ x, y, size, code }) {
+  return (
+    <img
+      src={getSvgFromCode(code)}
+      alt={""}
+      style={{
+        position: "absolute",
+        left: x,
+        top: y,
+        width: size,
+        height: size,
+      }}
+    />
+  );
+}
+
+function getSvgFromCode(code) {
+  const defaultMove = "/icons/clover.svg";
+  const defaultCapture = "/icons/level-four.svg";
+  const defaultPiece = "/icons/clover-spiked.svg";
+
+  switch (code) {
+    case 1:
+      return localStorage.getItem("icon-move") || defaultMove;
+    case 2:
+      return localStorage.getItem("icon-capture") || defaultCapture;
+    default:
+      return localStorage.getItem("icon-piece") || defaultPiece;
+  }
+}

--- a/src/pages/Game/Board/Board.jsx
+++ b/src/pages/Game/Board/Board.jsx
@@ -4,6 +4,17 @@ import { useGameDB } from "../GameHooks";
 import Panels from "./Panels";
 import Pieces from "./Pieces";
 
+const defaultPanels = [
+  [0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0],
+  [0, 0, 0, 0, 0, 0, 0, 0],
+];
+
 const BoardContext = createContext();
 export const useBoard = () => useContext(BoardContext);
 
@@ -11,6 +22,7 @@ function Board({ size }) {
   const { uid } = useAuth();
   const { game, playMove } = useGameDB();
   const positions = createPositions(size);
+  const [panels, setPanels] = useState(defaultPanels);
   const [activePiece, setActivePiece] = useState({});
   const [activeMoves, setActiveMoves] = useState([]);
 
@@ -31,7 +43,23 @@ function Board({ size }) {
         (move) => move.from.rank === rank && move.from.file === file
       );
       setActiveMoves(moves);
+      configurePanels(moves, rank, file);
     }
+  };
+
+  const configurePanels = (moves, activeRank, activeFile) => {
+    const copyPanels = defaultPanels.map((arr) => arr.slice());
+    copyPanels[activeRank][activeFile] = 3;
+
+    moves.forEach((move) => {
+      const { rank, file } = move.to;
+      if (move.capture) {
+        copyPanels[rank][file] = 2;
+      } else {
+        copyPanels[rank][file] = 1;
+      }
+    });
+    setPanels(copyPanels);
   };
 
   const playRankFile = (toRank, toFile) => {
@@ -46,6 +74,7 @@ function Board({ size }) {
   const removeFocus = () => {
     setActivePiece({});
     setActiveMoves([]);
+    setPanels(defaultPanels);
   };
 
   return (
@@ -61,6 +90,7 @@ function Board({ size }) {
         value={{
           positions,
           size,
+          panels,
           activeMoves,
           activePiece,
           getMovesFromRankFile,

--- a/src/pages/Game/Board/FrontPanels.jsx
+++ b/src/pages/Game/Board/FrontPanels.jsx
@@ -1,0 +1,105 @@
+import { useBoard } from "./Board";
+
+export default function FrontPanels() {
+  const { panels, positions, size } = useBoard();
+  const panelSize = size / 8;
+  const frontPanels = [];
+
+  for (let rank = 0; rank < 8; rank++) {
+    for (let file = 0; file < 8; file++) {
+      let panel;
+      const { x, y } = positions[rank][file];
+      switch (panels[rank][file]) {
+        case 0:
+          panel = (
+            <NormalPanel
+              x={x}
+              y={y}
+              size={panelSize}
+              key={`front-panel-${rank}-${file}`}
+            />
+          );
+          break;
+        case 1:
+          panel = (
+            <PiecePanel
+              x={x}
+              y={y}
+              size={panelSize}
+              rank={rank}
+              file={file}
+              key={`front-panel-${rank}-${file}`}
+            />
+          );
+          break;
+        case 2:
+        case 3:
+          panel = (
+            <MovePanel
+              x={x}
+              y={y}
+              size={panelSize}
+              rank={rank}
+              file={file}
+              key={`front-panel-${rank}-${file}`}
+            />
+          );
+          break;
+        default:
+          panel = (
+            <PiecePanel
+              x={x}
+              y={y}
+              size={panelSize}
+              rank={rank}
+              file={file}
+              key={`front-panel-${rank}-${file}`}
+            />
+          );
+      }
+      frontPanels.push(panel);
+    }
+  }
+  return frontPanels.map((panel) => panel);
+}
+
+function NormalPanel({ x, y, size }) {
+  const { removeFocus } = useBoard();
+
+  return <Panel x={x} y={y} size={size} onClick={removeFocus} />;
+}
+
+function PiecePanel({ x, y, size, rank, file }) {
+  const { getMovesFromRankFile } = useBoard();
+
+  const handleClick = () => {
+    getMovesFromRankFile(rank, file);
+  };
+
+  return <Panel x={x} y={y} size={size} onClick={handleClick} />;
+}
+
+function MovePanel({ x, y, size, rank, file }) {
+  const { playRankFile } = useBoard();
+
+  const handleClick = () => {
+    playRankFile(rank, file);
+  };
+
+  return <Panel x={x} y={y} size={size} onClick={handleClick} />;
+}
+
+function Panel({ x, y, size, onClick }) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: x,
+        top: y,
+        width: size,
+        height: size,
+      }}
+      onClick={onClick}
+    />
+  );
+}

--- a/src/pages/Game/Board/Pieces.jsx
+++ b/src/pages/Game/Board/Pieces.jsx
@@ -20,25 +20,16 @@ export default function Pieces() {
           x={x}
           y={y}
           size={pieceSize}
-          rank={rank}
-          file={file}
           key={`${code}-${rank}-${file}`}
         />
       );
     }
   }
-
   return pieces.map((piece) => piece);
 }
 
-function Piece({ code, x, y, size, rank, file }) {
-  const svgCode = getSvgCode(code);
-  const { getMovesFromRankFile } = useBoard();
-
-  const handleClick = () => {
-    console.log("get moves for rank file:", rank, file);
-    getMovesFromRankFile(rank, file);
-  };
+function Piece({ code, x, y, size }) {
+  const svgCode = getPieceSvgCode(code);
 
   return (
     <img
@@ -51,12 +42,11 @@ function Piece({ code, x, y, size, rank, file }) {
         width: size,
         height: size,
       }}
-      onClick={handleClick}
     />
   );
 }
 
-function getSvgCode(code) {
+function getPieceSvgCode(code) {
   let svgCode;
   if (code.toUpperCase() === code) {
     svgCode = "w" + code;


### PR DESCRIPTION
Separate Panels and Piece, and render logic to a clever, elegant, and manageable 3 layer system.

Goal behavior: to make a behavior where the panel behind of the pieces can have any image background, and make user able to click a piece to get its possible moves and move accordingly.

The problem with previous approach (of 2 layers of Panels and Pieces) is that when the user wants to capture a piece, aka move to a panel that have piece on top of it, they can't because the panel that they want to click on is blocked by the Piece image.

To solve this I decided to just refactor the whole thing into 3 layers system. The first (BackPanels) is only responsible for rendering an SVG background. The second (Pieces) is for rendering the Pieces, and nothing else. Lastly, the FrontPanels will be responsible for handling all the clicks from user.

How the new code works: The parent of all three layers, Board, is now responsible for handling the panels[][] state that store a 8x8 array of 0s, 1s, 2s, 3s, and 11. Each number has its own meaning and will be passed to both Back and Front Panels where it will then render the right image and behave accordingly